### PR TITLE
Add option to change tab title

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -9,13 +9,13 @@ const showCustomPage = ({ customNewTabUrl }) => {
 		return;
 	}
 
-	document.querySelector( 'html' ).classList.add( 'cntp-has-loaded' );
+	document.documentElement.classList.add( 'cntp-has-loaded' );
 
 	// The `type="content"` attribute is used for security purposes to avoid
 	// giving the iframe a privileged context that could be used to
 	// access browser (cookies, history, etc) or user files.
 	// See https://mdn.io/Displaying_web_content_in_an_extension_without_security_issues
-	const iframe = document.querySelector( '#cntp-iframe' );
+	const iframe = document.getElementById( 'cntp-iframe' );
 	iframe.src = customNewTabUrl;
 
 };

--- a/src/app.js
+++ b/src/app.js
@@ -1,7 +1,11 @@
 const log = false;
 
-const showCustomPage = ({ customNewTabUrl }) => {
+const showCustomPage = ({ customNewTabUrl, customNewTabTitle }) => {
 	log && console.debug( '[showCustomPage] init', { customNewTabUrl } );
+
+	if ( customNewTabTitle ) {
+		document.title = customNewTabTitle;
+	}
 
 	// no tab URL set, do nothing
 	if ( !customNewTabUrl || customNewTabUrl.length === 0 ) {
@@ -21,7 +25,7 @@ const showCustomPage = ({ customNewTabUrl }) => {
 };
 
 const init = _ => {
-	browser.storage.sync.get( 'customNewTabUrl' )
+	browser.storage.sync.get( ['customNewTabUrl', 'customNewTabTitle'] )
 		.then( showCustomPage );
 };
 

--- a/src/options.html
+++ b/src/options.html
@@ -21,6 +21,14 @@
 			<input class="form__input" type="text" id="customNewTabUrl" placeholder="https://example.com">
 		</div>
 
+		<div class="form__field">
+			<label class="form__label">New Tab Title</label>
+
+			<span class="form__hint">The text that is shown in the tab bar for the new tab.</span>
+
+			<input class="form__input" type="text" id="customNewTabTitle" placeholder="New Tab">
+		</div>
+
 		<footer class="form__actions">
 			<button class="btn" type="submit">Save</button>
 		</footer>

--- a/src/options.js
+++ b/src/options.js
@@ -2,7 +2,7 @@ const saveOptions = e => {
 	e.preventDefault();
 
 	browser.storage.sync.set({
-		customNewTabUrl: document.querySelector( '#customNewTabUrl' ).value,
+		customNewTabUrl: document.getElementById( 'customNewTabUrl' ).value,
 	});
 };
 
@@ -10,7 +10,7 @@ const restoreOptions = _ => {
 	const gettingItem = browser.storage.sync.get( 'customNewTabUrl' );
 
 	gettingItem.then( res => {
-		document.querySelector( '#customNewTabUrl' ).value = res.customNewTabUrl || '';
+		document.getElementById( 'customNewTabUrl' ).value = res.customNewTabUrl || '';
 	});
 };
 

--- a/src/options.js
+++ b/src/options.js
@@ -3,14 +3,16 @@ const saveOptions = e => {
 
 	browser.storage.sync.set({
 		customNewTabUrl: document.getElementById( 'customNewTabUrl' ).value,
+		customNewTabTitle: document.getElementById( 'customNewTabTitle' ).value,
 	});
 };
 
 const restoreOptions = _ => {
-	const gettingItem = browser.storage.sync.get( 'customNewTabUrl' );
+	const gettingItem = browser.storage.sync.get( ['customNewTabUrl', 'customNewTabTitle'] );
 
 	gettingItem.then( res => {
 		document.getElementById( 'customNewTabUrl' ).value = res.customNewTabUrl || '';
+		document.getElementById( 'customNewTabTitle' ).value = res.customNewTabTitle || '';
 	});
 };
 


### PR DESCRIPTION
Since the webpage is inside an iframe, the title of my custom page is not shown in the tab. Because of `type="content"` it's also not possible to change it via JavaScript.

So I added an option to define a static title from the options page.

I personally don't want to have a title at all, but using an empty string will have no effect. So I use `&nbsp;` instead. That's why I assign it to `innerHTML`.

Alternatively the title could be set via `document.title`. That won't allow HTML entities, but it would still be possible to insert the resulting character instead. I just find `&nbsp;` to be clearer than an visually ambiguous space.