### PR TITLE
use colorpicker instead of themes

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -11,6 +11,7 @@ body {
 	overflow: hidden;
 	width: 100vw;
 	height: 100vh;
+	background-color: #000;
 }
 
 .cntp-iframe {
@@ -20,4 +21,5 @@ body {
 	width: 100vw;
 	height: 100vh;
 	border: 0;
+	background-color: #000;
 }

--- a/src/app.css
+++ b/src/app.css
@@ -13,14 +13,6 @@ body {
 	height: 100vh;
 }
 
-body.t-light {
-	background-color: #fff;
-}
-
-body.t-dark {
-	background-color: #323234;
-}
-
 .cntp-iframe {
 	position: absolute;
 	top: 0;

--- a/src/app.js
+++ b/src/app.js
@@ -3,12 +3,8 @@ const log = false;
 const showCustomPage = ({ customNewTabUrl, customNewTabTitle, theme }) => {
 	log && console.debug( '[showCustomPage] init', { customNewTabUrl, customNewTabTitle, theme } );
 
-	if ( theme === 'light' ) {
-		document.body.classList.add( 't-light' );
-	}
-
-	if ( theme === 'dark' ) {
-		document.body.classList.add( 't-dark' );
+	if ( theme ) {
+		document.body.backgroundColor = theme;
 	}
 
 	if ( customNewTabTitle ) {
@@ -25,6 +21,7 @@ const showCustomPage = ({ customNewTabUrl, customNewTabTitle, theme }) => {
 
 	const onload = _ => document.body.classList.remove( 'is-loading' );
 	const iframe = document.getElementById( 'cntp-iframe' );
+	if ( theme ) { iframe.body.style.backgroundColor = theme }
 	iframe.onload = onload;
 	iframe.src = customNewTabUrl;
 };

--- a/src/app.js
+++ b/src/app.js
@@ -21,7 +21,7 @@ const showCustomPage = ({ customNewTabUrl, customNewTabTitle, theme }) => {
 
 	const onload = _ => document.body.classList.remove( 'is-loading' );
 	const iframe = document.getElementById( 'cntp-iframe' );
-	if ( theme ) { iframe.body.style.backgroundColor = theme }
+	if ( theme ) { iframe.body.style.backgroundColor = theme; }
 	iframe.onload = onload;
 	iframe.src = customNewTabUrl;
 };

--- a/src/options.html
+++ b/src/options.html
@@ -34,11 +34,7 @@
 
 			<span class="form__hint">The background colour used while the page is loading.</span>
 
-			<select class="form__input form__input--select" id="theme">
-				<option value="none">None</option>
-				<option value="light">Light</option>
-				<option value="dark">Dark</option>
-			</select>
+			<input class="form__input form__input--textlike" type="color" id="theme" value="#0E0E0E">
 		</div>
 
 		<footer class="form__actions">

--- a/src/options.js
+++ b/src/options.js
@@ -13,7 +13,7 @@ const restoreOptions = _ => {
 		.then( options => {
 			document.getElementById( 'customNewTabUrl' ).value = options.customNewTabUrl || '';
 			document.getElementById( 'customNewTabTitle' ).value = options.customNewTabTitle || '';
-			document.getElementById( 'theme' ).value = options.theme || 'none';
+			document.getElementById( 'theme' ).value = options.theme || 'transparent';
 		});
 };
 


### PR DESCRIPTION
This is a pretty simple fix for #6, the colorpicker could be made prettier instead of using the default one for input type color and maybe `theme` should be renamed now, but it works.

Unfortunately the white flashing issue #3 can only be solved with a fixed color in the app.css or as inline style. Loading the custom color from options is too slow, the best I could do was to turn the bright white flash into a less noticable black flash by adding `background-color: #000` to both body and iframe.

resolves #6

