### PR TITLE
Add option to force links to open in the top frame

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
 
 	rules: {
 		'no-param-reassign'     : 'off',
+		'no-shadow'             : [ 'error', { allow: [ '_' ] }],
 		'no-unused-expressions' : [ 'warn', { allowShortCircuit: true, allowTernary: true } ],
 		'keyword-spacing'       : [ 'error', { 'before': true, 'after': true } ]
 	},

--- a/src/background.js
+++ b/src/background.js
@@ -1,0 +1,182 @@
+// flags
+const log = false;
+
+
+// globals
+const extensionNewTabPath = 'app.html';
+
+// TODO: this also exists in options.js and could be moved to a separate helper file
+const forceOpenInTopFramePermissions = [
+	'webRequest',
+	'webRequestBlocking',
+];
+
+
+// state
+let options = {
+	customNewTabUrl: '',
+	forceOpenInTopFrame: false,
+};
+
+
+// Firefox API helpers
+
+// TODO: this also exists in options.js and could be moved to a separate helper file
+const toMatchPattern = urlStr => {
+	try {
+		// Match patterns without paths must have a trailing slash.
+		// URL.toString adds a trailing slash when needed, e.g.
+		// new URL( 'https://example.org' ).toString() // -> 'https://example.org/'
+		return new URL( urlStr ).toString();
+	} catch ( err ) {
+		console.error( '#toMatchPattern', err );
+		return false;
+	}
+};
+
+
+const updateOptionsCache = opts => { options = Object.assign( {}, options, opts ); };
+
+const refreshOptionsCache = async _ => await browser.storage.sync.get([ 'customNewTabUrl', 'forceOpenInTopFrame' ]).then( updateOptionsCache );
+
+const customNewTabUrlExists = _ => ( options.customNewTabUrl && options.customNewTabUrl.length !== 0 );
+
+const applyFilter = details => {
+	log && console.debug( '#applyFilter', options, details );
+
+	if ( !options.forceOpenInTopFrame ) {
+		// Dont modify requests if the option is not enabled.
+		log && console.debug( '#applyFilter // forceOpenInTopFrame option not enabled... skipping' );
+		return false;
+	}
+
+	if ( details.originUrl !== browser.extension.getURL( extensionNewTabPath ) ) {
+		// Don't modify requests outside of the extension new tab page.
+		// This is still needed because the `customNewTabUrl` scope used in the onBeforeRequest listener doesnt guarantee the request is coming from this extension.
+		log && console.debug( '#applyFilter // outside of extension new tab page... skipping' );
+		return false;
+	}
+
+	log && console.debug( '#applyFilter // modifying', { url: details.url, originUrl: details.originUrl } );
+
+	const decoder = new TextDecoder( 'utf-8' );
+	const encoder = new TextEncoder();
+	const filter = browser.webRequest.filterResponseData( details.requestId );
+
+	// This only modifies `details.url` which is `options.customNewTabUrl`.
+	// The extension page, `details.originUrl`, is not changed.
+	filter.ondata = event => {
+		let str = decoder.decode( event.data, { stream: true } );
+		// insert the <base> tag just before the closing </head>
+		str = str.replace( /<\/head>/g, '<base target="_top">\n</head>' );
+
+		filter.write( encoder.encode( str ) );
+		filter.disconnect();
+	};
+
+	return true;
+};
+
+
+const listener = async details => {
+	try {
+		return applyFilter( details );
+	} catch ( err ) {
+		console.error( '#listener', err );
+		return false;
+	}
+};
+
+
+const removeRequestListener = _ => {
+	const hasListener = browser.webRequest.onBeforeRequest.hasListener( listener );
+	log && console.debug( '#removeRequestListener', { hasListener } );
+
+	if ( hasListener ) {
+		browser.webRequest.onBeforeRequest.removeListener( listener );
+	}
+};
+
+const addRequestListener = _ => {
+	log && console.debug( '#addRequestListener' );
+
+	if ( !customNewTabUrlExists() ) {
+		return false;
+	}
+
+	const customNewTabUrlMatchPattern = toMatchPattern( options.customNewTabUrl );
+	log && console.debug( '#addRequestListener', { customNewTabUrlMatchPattern } );
+
+	if ( !customNewTabUrlMatchPattern ) {
+		return false;
+	}
+
+	// clean up old listeners
+	removeRequestListener();
+
+	browser.webRequest.onBeforeRequest.addListener(
+		listener,
+		{
+			urls: [
+				browser.extension.getURL( extensionNewTabPath ),
+				customNewTabUrlMatchPattern,
+			],
+			types: [ 'sub_frame' ],
+		},
+		[ 'blocking' ],
+	);
+
+	return true;
+};
+
+
+const hasPermissions = async _ => {
+	try {
+		const requiredPermissions = {
+			permissions:  forceOpenInTopFramePermissions,
+			origins: [ toMatchPattern( options.customNewTabUrl ) ],
+		};
+
+		const hasPermissions_ = await browser.permissions.contains( requiredPermissions );
+		log && console.debug( '#hasPermissions', { requiredPermissions, hasPermissions_ } );
+
+		return hasPermissions_;
+	} catch ( err ) {
+		console.error( '#hasPermissions // error', err );
+		return false;
+	}
+};
+
+
+const init = async _ => {
+	try {
+		log && console.debug( '#init' );
+
+		await refreshOptionsCache();
+		log && console.debug( '#init // got options', options );
+
+		if ( options.forceOpenInTopFrame && customNewTabUrlExists() && await hasPermissions() ) {
+			log && console.debug( '#init // has permissions, url exists, option set -- adding request listener' );
+			addRequestListener();
+		} else {
+			log && console.debug( '#init // either no permissions OR no url OR option is disabled -- do nothing' );
+		}
+	} catch ( err ) {
+		console.error( '#init', err );
+	}
+};
+
+
+const addOptionsListener = _ => {
+	log && console.debug( '#addOptionsListener' );
+	return browser.storage.onChanged.addListener( _ => {
+		log && console.debug( 'storage.onChanged' );
+		init();
+	});
+};
+
+
+// this listener should only be added once so it's separate from init
+addOptionsListener();
+
+init();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -24,7 +24,17 @@
   "permissions": [
     "storage"
   ],
+  "optional_permissions": [
+    "webRequest",
+    "webRequestBlocking",
+    "<all_urls>"
+  ],
   "chrome_url_overrides" : {
     "newtab": "app.html"
+  },
+  "background": {
+    "scripts": [
+      "background.js"
+    ]
   }
 }

--- a/src/options.html
+++ b/src/options.html
@@ -47,6 +47,20 @@
 
 		</div>
 
+		<div class="form__field">
+			<label class="form__label" for="forceOpenInTopFrame">Force links to open in the top frame (experimental)?</label>
+
+			<input type="checkbox" id="forceOpenInTopFrame">
+
+			<span class="form__hint">
+				If checked then this will attempt to make all links on the new tab page open in the top level frame.
+				<br>
+				This requires several extra permissions which you will be prompted to allow if you check this box.
+				<br>
+				<strong>Warning, this is very experimental! Enabling this might cause problems and unexpected behaviour on the site used as your new tab page!</strong>
+			</span>
+		</div>
+
 		<footer class="form__actions">
 			<button class="btn" type="submit">Save</button>
 		</footer>

--- a/src/options.js
+++ b/src/options.js
@@ -1,5 +1,117 @@
+// flags
+const log = false;
+
+
+// globals
 const hiddenClass = 'is-hidden';
 
+
+// Firefox API helpers
+const toMatchPattern = urlStr => {
+	try {
+		// Match patterns without paths must have a trailing slash.
+		// URL.toString adds a trailing slash when needed, e.g.
+		// new URL( 'https://example.org' ).toString() // -> 'https://example.org/'
+		return new URL( urlStr ).toString();
+	} catch ( err ) {
+		console.error( '#toMatchPattern', err );
+		return false;
+	}
+};
+
+
+// option: forceOpenInTopFrame
+const getForceOpenInTopFrameValue = _ => {
+	const value = document.getElementById( 'forceOpenInTopFrame' ).checked;
+	log && console.debug( '#getForceOpenInTopFrameValue', value );
+
+	return value;
+};
+
+
+const setForceOpenInTopFrameValue = value => {
+	log && console.debug( '#setForceOpenInTopFrameValue', value );
+	document.getElementById( 'forceOpenInTopFrame' ).checked = value;
+};
+
+
+const forceOpenInTopFramePermissions = [
+	'webRequest',
+	'webRequestBlocking',
+];
+
+
+const revokeForceOpenInTopFramePermissions = async _ => {
+	const revokedSuccessfully = await browser.permissions.remove({ permissions: forceOpenInTopFramePermissions });
+	log && console.debug( '#revokeForceOpenInTopFramePermissions', { revokedSuccessfully } );
+
+	return revokedSuccessfully;
+};
+
+
+const requestForceOpenInTopFramePermissions = async _ => {
+	const customNewTabUrl = document.getElementById( 'customNewTabUrl' ).value;
+	const matchPattern = toMatchPattern( customNewTabUrl );
+
+	log && console.debug( '#requestForceOpenInTopFramePermissions', { matchPattern } );
+
+	if ( !matchPattern ) {
+		// TODO: if the URL is not valid for forceOpenInTopFrame the option should be disabled with a note explaining why!
+		return false;
+	}
+
+	const permissionsToRequest = {
+		permissions: forceOpenInTopFramePermissions,
+		origins: [ matchPattern ],
+	};
+
+	let permissionsGranted = false;
+
+	try {
+		permissionsGranted = await browser.permissions.request( permissionsToRequest );
+	} catch ( err ) {
+		console.error( '#requestForceOpenInTopFramePermissions // request permissions failed', err );
+	}
+
+	log && console.debug( '#requestForceOpenInTopFramePermissions', permissionsToRequest, { permissionsGranted } );
+
+	return permissionsGranted;
+};
+
+
+const maybeRequestForceOpenInTopFramePermissions = async _ => {
+	const customNewTabUrl = document.getElementById( 'customNewTabUrl' ).value;
+
+	if ( customNewTabUrl && getForceOpenInTopFrameValue() ) {
+		const permissionsGranted = await requestForceOpenInTopFramePermissions();
+
+		if ( !permissionsGranted ) {
+			setForceOpenInTopFrameValue( false );
+		}
+	}
+
+	return null;
+};
+
+
+const forceOpenInTopFrameChanged = async _ => {
+	const forceOpenInTopFrameEnabled = getForceOpenInTopFrameValue();
+	log && console.debug( '#forceOpenInTopFrameChanged', { forceOpenInTopFrameEnabled } );
+
+	if ( forceOpenInTopFrameEnabled ) {
+		const permissionsGranted = await requestForceOpenInTopFramePermissions();
+		log && console.debug( '#forceOpenInTopFrameChanged', { permissionsGranted } );
+
+		if ( !permissionsGranted ) {
+			setForceOpenInTopFrameValue( false );
+		}
+	} else {
+		revokeForceOpenInTopFramePermissions();
+	}
+};
+
+
+// option: theme
 const updateCustomBackgroundColorVisibility = _ => {
 	const theme = document.getElementById( 'theme' ).value;
 
@@ -10,29 +122,57 @@ const updateCustomBackgroundColorVisibility = _ => {
 	}
 };
 
-const saveOptions = e => {
+
+// general form
+const saveOptions = async e => {
 	e.preventDefault();
 
-	browser.storage.sync.set({
+	const options = {
 		customNewTabUrl: document.getElementById( 'customNewTabUrl' ).value,
 		customNewTabTitle: document.getElementById( 'customNewTabTitle' ).value,
 		theme: document.getElementById( 'theme' ).value,
 		customBackgroundColor: document.getElementById( 'customBackgroundColor' ).value,
-	});
+		forceOpenInTopFrame: getForceOpenInTopFrameValue(),
+	};
+
+	log && console.debug( '#saveOptions', options );
+
+	await browser.storage.sync.set( options );
 };
 
-const restoreOptions = _ => {
-	browser.storage.sync.get([ 'customNewTabUrl', 'customNewTabTitle', 'theme', 'customBackgroundColor' ])
-		.then( options => {
-			document.getElementById( 'customNewTabUrl' ).value = options.customNewTabUrl || '';
-			document.getElementById( 'customNewTabTitle' ).value = options.customNewTabTitle || '';
-			document.getElementById( 'theme' ).value = options.theme || 'none';
-			document.getElementById( 'customBackgroundColor' ).value = options.customBackgroundColor || '';
 
-			updateCustomBackgroundColorVisibility();
-		});
+const restoreOptions = async _ => {
+	const options = await browser.storage.sync.get([
+		'customNewTabUrl',
+		'customNewTabTitle',
+		'theme',
+		'customBackgroundColor',
+		'forceOpenInTopFrame',
+	]);
+
+	log && console.debug( '#restoreOptions', options );
+
+	document.getElementById( 'customNewTabUrl' ).value = options.customNewTabUrl || '';
+	document.getElementById( 'customNewTabTitle' ).value = options.customNewTabTitle || '';
+	document.getElementById( 'theme' ).value = options.theme || 'none';
+	document.getElementById( 'customBackgroundColor' ).value = options.customBackgroundColor || '';
+
+	setForceOpenInTopFrameValue( typeof options.forceOpenInTopFrame === 'undefined' ? false : options.forceOpenInTopFrame );
+
+	updateCustomBackgroundColorVisibility();
+
+	// TODO: requesting permissions can only be done from a user event handler (e.g. click).
+	// We can either assume the correct permissions have been granted,
+	// or check and show a button to request them (or just change the forceOpenInTopFrame to false) if they have not been granted.
 };
 
+
+// event listeners
 document.addEventListener( 'DOMContentLoaded', restoreOptions );
 document.querySelector( 'form' ).addEventListener( 'submit', saveOptions );
+
+// this blur will fail with `permissions.request may only be called from a user input handler` if the input is programatically blurred (e.g. by changing tab while focused on the input) but thats ok.
+document.getElementById( 'customNewTabUrl' ).addEventListener( 'blur', maybeRequestForceOpenInTopFramePermissions );
+
 document.getElementById( 'theme' ).addEventListener( 'change', updateCustomBackgroundColorVisibility );
+document.getElementById( 'forceOpenInTopFrame' ).addEventListener( 'change', forceOpenInTopFrameChanged );


### PR DESCRIPTION
This is an **experimental** solution for #1 so it must be enabled from the add-on options page before it will do anything.

It works by intercepting the request and injecting the tag `<base target="_top">` just before the closing `</head>` tag.