### PR TITLE
Add option to remove `X-Frame-Options` header

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,12 @@ module.exports = {
 			allowShortCircuit: true,
 			allowTernary: true,
 		}],
+		'no-unused-vars': [ 'warn', {
+			vars: 'all',
+			args: 'none',
+			argsIgnorePattern: '^_$',
+			ignoreRestSiblings: true,
+		}],
 		'no-warning-comments': [ 'warn', {
 			terms: [ 'fixme', 'xxx' ],
 			location: 'start',

--- a/src/background.js
+++ b/src/background.js
@@ -5,7 +5,13 @@ const log = false;
 // globals
 const extensionNewTabPath = 'app.html';
 
-// TODO: this also exists in options.js and could be moved to a separate helper file
+// TODO: this also exists in options.js and could be moved to a separate helper file.
+const removeIframeHeadersPermissions = [
+	'webRequest',
+	'webRequestBlocking',
+];
+
+// TODO: this also exists in options.js and could be moved to a separate helper file.
 const forceOpenInTopFramePermissions = [
 	'webRequest',
 	'webRequestBlocking',
@@ -15,13 +21,14 @@ const forceOpenInTopFramePermissions = [
 // state
 let options = {
 	customNewTabUrl: '',
+	removeIframeHeaders: false,
 	forceOpenInTopFrame: false,
 };
 
 
 // Firefox API helpers
 
-// TODO: this also exists in options.js and could be moved to a separate helper file
+// TODO: this also exists in options.js and could be moved to a separate helper file.
 const toMatchPattern = urlStr => {
 	try {
 		// Match patterns without paths must have a trailing slash.
@@ -34,30 +41,53 @@ const toMatchPattern = urlStr => {
 	}
 };
 
+// TODO: this also exists in options.js and could be moved to a separate helper file.
+// Creates a matcher for any page on a given domain.
+// toWildcardDomainMatchPattern('https://example.com') // -> 'https://*.example.com/*'
+// toWildcardDomainMatchPattern('https://example.com:3000/foo/bar.html') // -> 'https://*.example.com:3000/*'
+const toWildcardDomainMatchPattern = urlStr => {
+	try {
+		const url = new URL( urlStr );
+		const pattern = `${url.protocol}//*.${url.host}/*`;
+
+		log && console.debug( '#toWildcardDomainMatchPattern', { pattern } );
+		return pattern;
+	} catch ( err ) {
+		console.error( '#toWildcardDomainMatchPattern', err );
+		return false;
+	}
+};
+
 
 const updateOptionsCache = opts => { options = Object.assign( {}, options, opts ); };
 
-const refreshOptionsCache = async _ => await browser.storage.sync.get([ 'customNewTabUrl', 'forceOpenInTopFrame' ]).then( updateOptionsCache );
+const refreshOptionsCache = async _ =>
+	await browser.storage.sync.get([
+		'customNewTabUrl',
+		'removeIframeHeaders',
+		'forceOpenInTopFrame',
+	]).then( updateOptionsCache );
 
 const customNewTabUrlExists = _ => ( options.customNewTabUrl && options.customNewTabUrl.length !== 0 );
 
-const applyFilter = details => {
-	log && console.debug( '#applyFilter', options, details );
+
+const forceOpenInTopFrameFilter = details => {
+	log && console.debug( '#forceOpenInTopFrameFilter', options, details );
 
 	if ( !options.forceOpenInTopFrame ) {
 		// Dont modify requests if the option is not enabled.
-		log && console.debug( '#applyFilter // forceOpenInTopFrame option not enabled... skipping' );
+		log && console.debug( '#forceOpenInTopFrameFilter // forceOpenInTopFrame option not enabled... skipping' );
 		return false;
 	}
 
 	if ( details.originUrl !== browser.extension.getURL( extensionNewTabPath ) ) {
 		// Don't modify requests outside of the extension new tab page.
 		// This is still needed because the `customNewTabUrl` scope used in the onBeforeRequest listener doesnt guarantee the request is coming from this extension.
-		log && console.debug( '#applyFilter // outside of extension new tab page... skipping' );
+		log && console.debug( '#forceOpenInTopFrameFilter // outside of extension new tab page... skipping' );
 		return false;
 	}
 
-	log && console.debug( '#applyFilter // modifying', { url: details.url, originUrl: details.originUrl } );
+	log && console.debug( '#forceOpenInTopFrameFilter // modifying', { url: details.url, originUrl: details.originUrl } );
 
 	const decoder = new TextDecoder( 'utf-8' );
 	const encoder = new TextEncoder();
@@ -77,23 +107,70 @@ const applyFilter = details => {
 	return true;
 };
 
+const removeIframeHeadersFilter = details => {
+	log && console.debug( '#removeIframeHeadersFilter', options, details );
 
-const listener = async details => {
+	if ( !options.removeIframeHeaders ) {
+		// Dont modify requests if the option is not enabled.
+		log && console.debug( '#removeIframeHeadersFilter // removeIframeHeaders option not enabled... skipping' );
+		return false;
+	}
+
+	if ( details.originUrl !== browser.extension.getURL( extensionNewTabPath ) ) {
+		// Don't modify requests outside of the extension new tab page.
+		// This is still needed because the `customNewTabUrl` scope used in the onHeadersReceived listener doesnt guarantee the request is coming from this extension.
+		log && console.debug( '#removeIframeHeadersFilter // outside of extension new tab page... skipping' );
+		return false;
+	}
+
+	log && console.debug( '#removeIframeHeadersFilter // modifying', { url: details.url, originUrl: details.originUrl } );
+
+	const responseHeaders = details.responseHeaders.filter(header => {
+		return header.name.toLowerCase() !== 'x-frame-options';
+	});
+
+	log && console.debug( '#removeIframeHeadersFilter // new response headers', responseHeaders );
+
+	// NOTE: changes made here will **not** show up in the browser DevTools network tab.
+	return { responseHeaders };
+};
+
+
+const onBeforeRequestListener = async details => {
 	try {
-		return applyFilter( details );
+		return forceOpenInTopFrameFilter( details );
 	} catch ( err ) {
-		console.error( '#listener', err );
+		console.error( '#onBeforeRequestListener', err );
 		return false;
 	}
 };
 
 
-const removeRequestListener = _ => {
-	const hasListener = browser.webRequest.onBeforeRequest.hasListener( listener );
-	log && console.debug( '#removeRequestListener', { hasListener } );
+const onBeforeRequestListenerCleanup = _ => {
+	const hasListener = browser.webRequest.onBeforeRequest.hasListener( onBeforeRequestListener );
+	log && console.debug( '#onBeforeRequestListenerCleanup', { hasListener } );
 
 	if ( hasListener ) {
-		browser.webRequest.onBeforeRequest.removeListener( listener );
+		browser.webRequest.onBeforeRequest.removeListener( onBeforeRequestListener );
+	}
+};
+
+const onHeadersReceivedListener = async details => {
+	try {
+		return removeIframeHeadersFilter( details );
+	} catch ( err ) {
+		console.error( '#onHeadersReceivedListener', err );
+		return false;
+	}
+};
+
+
+const onHeadersReceivedListenerCleanup = _ => {
+	const hasListener = browser.webRequest.onHeadersReceived.hasListener( onHeadersReceivedListener );
+	log && console.debug( '#onHeadersReceivedListenerCleanup', { hasListener } );
+
+	if ( hasListener ) {
+		browser.webRequest.onHeadersReceived.removeListener( onHeadersReceivedListener );
 	}
 };
 
@@ -104,37 +181,69 @@ const addRequestListener = _ => {
 		return false;
 	}
 
-	const customNewTabUrlMatchPattern = toMatchPattern( options.customNewTabUrl );
-	log && console.debug( '#addRequestListener', { customNewTabUrlMatchPattern } );
+	// TODO: this logic is duplicated in options.js and should be centralized somewhere.
+	const forceOpenInTopFrameCustomNewTabUrlMatchPattern = toMatchPattern( options.customNewTabUrl );
+	log && console.debug( '#addRequestListener', { forceOpenInTopFrameCustomNewTabUrlMatchPattern } );
 
-	if ( !customNewTabUrlMatchPattern ) {
-		return false;
+	onBeforeRequestListenerCleanup();
+
+	if ( forceOpenInTopFrameCustomNewTabUrlMatchPattern ) {
+		browser.webRequest.onBeforeRequest.addListener(
+			onBeforeRequestListener,
+			{
+				urls: [
+					browser.extension.getURL( extensionNewTabPath ),
+					forceOpenInTopFrameCustomNewTabUrlMatchPattern,
+				],
+				types: [ 'sub_frame' ],
+			},
+			[ 'blocking' ],
+		);
 	}
 
-	// clean up old listeners
-	removeRequestListener();
+	// TODO: this logic is duplicated in options.js and should be centralized somewhere.
+	const removeIframeHeadersCustomNewTabUrlMatchPattern = toWildcardDomainMatchPattern( options.customNewTabUrl );
+	log && console.debug( '#addRequestListener', { removeIframeHeadersCustomNewTabUrlMatchPattern } );
 
-	browser.webRequest.onBeforeRequest.addListener(
-		listener,
-		{
-			urls: [
-				browser.extension.getURL( extensionNewTabPath ),
-				customNewTabUrlMatchPattern,
-			],
-			types: [ 'sub_frame' ],
-		},
-		[ 'blocking' ],
-	);
+	onHeadersReceivedListenerCleanup();
+
+	if ( removeIframeHeadersCustomNewTabUrlMatchPattern ) {
+		browser.webRequest.onHeadersReceived.addListener(
+			onHeadersReceivedListener,
+			{
+				urls: [
+					browser.extension.getURL( extensionNewTabPath ),
+					removeIframeHeadersCustomNewTabUrlMatchPattern,
+				],
+				types: [ 'sub_frame' ],
+			},
+			[ 'blocking', 'responseHeaders' ],
+		);
+	}
 
 	return true;
 };
 
 
+// TODO: this logic is duplicated in options.js and should be centralized somewhere.
 const hasPermissions = async _ => {
 	try {
+		let permissions = [];
+		let origins = [];
+
+		if ( options.removeIframeHeaders ) {
+			permissions = permissions.concat( removeIframeHeadersPermissions );
+			origins = origins.concat( toWildcardDomainMatchPattern( options.customNewTabUrl ) );
+		}
+
+		if ( options.forceOpenInTopFrame ) {
+			permissions = permissions.concat( forceOpenInTopFramePermissions );
+			origins = origins.concat( toMatchPattern( options.customNewTabUrl ) );
+		}
+
 		const requiredPermissions = {
-			permissions:  forceOpenInTopFramePermissions,
-			origins: [ toMatchPattern( options.customNewTabUrl ) ],
+			permissions,
+			origins,
 		};
 
 		const hasPermissions_ = await browser.permissions.contains( requiredPermissions );
@@ -155,7 +264,7 @@ const init = async _ => {
 		await refreshOptionsCache();
 		log && console.debug( '#init // got options', options );
 
-		if ( options.forceOpenInTopFrame && customNewTabUrlExists() && await hasPermissions() ) {
+		if ( (options.removeIframeHeaders || options.forceOpenInTopFrame) && customNewTabUrlExists() && await hasPermissions() ) {
 			log && console.debug( '#init // has permissions, url exists, option set -- adding request listener' );
 			addRequestListener();
 		} else {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -25,9 +25,9 @@
     "storage"
   ],
   "optional_permissions": [
+    "<all_urls>",
     "webRequest",
-    "webRequestBlocking",
-    "<all_urls>"
+    "webRequestBlocking"
   ],
   "chrome_url_overrides" : {
     "newtab": "app.html"

--- a/src/options.css
+++ b/src/options.css
@@ -1,6 +1,12 @@
 /* GENERIC HELPER */
 .is-hidden { display: none !important; }
 
+/* GENERIC OTHER */
+.code {
+	padding: 0 2px;
+	background-color: #e6e6e6;
+	font-size: inherit;
+}
 
 /* GENERIC FORM */
 .form {

--- a/src/options.html
+++ b/src/options.html
@@ -15,7 +15,7 @@
 			<span class="form__hint">
 				The URL to show when a new tab is opened. It should include the "https" or "http" part.
 				<br>
-				The site must allow iframe embedding or it won’t work.
+				If the site does not allow iframe embedding enable the "Remove iframe headers" option below.
 			</span>
 
 			<input class="form__input form__input--textlike" type="text" id="customNewTabUrl" placeholder="https://example.com">
@@ -45,6 +45,20 @@
 				<input class="form__input field-theme__custom-background-color is-hidden" type="color" id="customBackgroundColor">
 			</div>
 
+		</div>
+
+		<div class="form__field">
+			<label class="form__label" for="removeIframeHeaders">Remove iframe headers?</label>
+
+			<input type="checkbox" id="removeIframeHeaders">
+
+			<span class="form__hint">
+				If checked then this will remove any <code class="code">X-Frame-Options</code> headers from your new tab URL.
+				<br>
+				If you see an error like "Blocked by X-Frame-Options Policy" or "To protect your security, example.com will not allow Firefox to display the page if another site has embedded it. To see this page, you need to open it in a new window." then you can enable this option to get around the error.
+				<br>
+				This requires several extra permissions which you will be prompted to allow if you check this box.
+			</span>
 		</div>
 
 		<div class="form__field">


### PR DESCRIPTION
This fixes #12 by giving the user the option to remove `X-Frame-Options` headers from the new tab URL.

It's optional because it requires extra permissions.