### PR TITLE
Remove CSP together with X-Frame-Options

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -126,7 +126,8 @@ const removeIframeHeadersFilter = details => {
 	log && console.debug( '#removeIframeHeadersFilter // modifying', { url: details.url, originUrl: details.originUrl } );
 
 	const responseHeaders = details.responseHeaders.filter(header => {
-		return header.name.toLowerCase() !== 'x-frame-options';
+		return header.name.toLowerCase() !== 'x-frame-options' &&
+			header.name.toLowerCase() !== 'content-security-policy';
 	});
 
 	log && console.debug( '#removeIframeHeadersFilter // new response headers', responseHeaders );


### PR DESCRIPTION
Container-Security-Policy header can be used for the same purpose as X-Frame-Options, so sometimes it needs to be removed too